### PR TITLE
feat: semaphore syncing

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,0 +1,40 @@
+local config = require 'config.client'
+
+---@type table<string, integer>
+local states = {}
+
+---Sets a boolean state. Runs its onSet function if the state is not previously set and the onSet function exists in config
+---@param name string
+---@return boolean firstSetter true if the state had not previously been set
+local function setState(name)
+    if not states[name] then
+        if config.states[name]?.onSet then
+            config.states[name].onSet()
+        end
+        states[name] = 1
+        return true
+    else
+        states[name] += 1
+        return false
+    end
+end
+
+---Releases a boolean state. Runs its onRelease function if this is the last call to release the state and the release function exists in config.
+---@param name string
+---@return boolean lastReleaser true if the state is fully released after this function
+local function releaseState(name)
+    if not states[name] then states[name] = 0 end
+    if states[name] <= 1 then
+        states[name] = nil
+        if config.states[name]?.onRelease() then
+            config.states[name].onRelease()
+        end
+        return true
+    else
+        states[name] -= 1
+        return false
+    end
+end
+
+exports('SetState', setState)
+exports('ReleaseState', releaseState)

--- a/client.lua
+++ b/client.lua
@@ -21,10 +21,11 @@ end
 
 ---Releases a boolean state. Runs its onRelease function if this is the last call to release the state and the release function exists in config.
 ---@param name string
+---@param force? boolean if true, releases the state regardless of the number of locks on it
 ---@return boolean lastReleaser true if the state is fully released after this function
-local function releaseState(name)
-    if not states[name] then states[name] = 0 end
-    if states[name] <= 1 then
+local function releaseState(name, force)
+    if not states[name] then return true end
+    if states[name] <= 1 or force then
         states[name] = nil
         if config.states[name]?.onRelease() then
             config.states[name].onRelease()

--- a/client.lua
+++ b/client.lua
@@ -24,7 +24,7 @@ end
 ---@param force? boolean if true, releases the state regardless of the number of locks on it
 ---@return boolean lastReleaser true if the state is fully released after this function
 local function releaseState(name, force)
-    if not states[name] then return true end
+    if not states[name] then return false end
     if states[name] <= 1 or force then
         states[name] = nil
         if config.states[name]?.onRelease() then

--- a/config/client.lua
+++ b/config/client.lua
@@ -1,0 +1,4 @@
+return {
+    ---@type table<string, State>
+    states = {}
+}

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,0 +1,18 @@
+fx_version 'cerulean'
+game 'gta5'
+
+name 'qbx_playerstates'
+description 'Manage the state of the player'
+repository 'https://github.com/Qbox-project/qbx_playerstates'
+version '0.0.0'
+
+client_scripts {
+    'client.lua',
+}
+
+files {
+    'config/client.lua',
+}
+
+lua54 'yes'
+use_experimental_fxv2_oal 'yes'

--- a/types.lua
+++ b/types.lua
@@ -1,0 +1,5 @@
+---@meta
+
+---@class State
+---@field onSet? function
+---@field onRelease? function


### PR DESCRIPTION
Initialize resource with basic files and create two exports

SetState & ReleaseState. This aims to solve the problem of setting a state in one resource, but another resource releases the state. 

An example is not being able to access your inventory while handcuffed. If you are handcuffed and then die, in our current world your player will have two states set, handcuffed and dead. However, if while dead you get unhandcuffed, unless the unhandcuff logic is checking for this, you will be able to access your inventory again. This is because the unhand cuff logic assumes that you couldn't access your inventory because off our handcuffs, when in reality you shouldn't be able to access your inventory because of both the medical and handcuff logic!

To solve this, in the world of this PR, both medical and handcuff logic would set the player's inventory block state using SetState. Only the first set to do so would cause the inventory to be blocked, then each would call ReleaseState when they no longer need the inventory blocked. Only once all scripts which set state release it, will the state be released.

This is possible to use today with no configuration:

```lua
if exports.qbx_playerstates:SetState('handcuffed') then
    --- play a handcuffed animation, set state bag, disable certain controls, etc
end

if exports.qbx_playerstates:ReleaseState('handcuffed') then
    --- play an unhandcuffed animation, set state bag, re-enable controls, etc.
end
```

However the onSet and onRelease functions are optional configuration entries as well to avoid needing to repeat common functions between resources. This also allows for meta stases; states which aggregate and set other states. This can be useful for things like disabling all controls, which may involve many native and export calls. As long as states are set through the exports, this synchronization and centralization of management can occur to prevent edge case bugs currently possible today.

